### PR TITLE
Updated test_conn to cluster_info

### DIFF
--- a/cluster_info.yml
+++ b/cluster_info.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   tasks:
     - name: Test connection to Rubrik 
-      test_conn:
+      cluster_info:
         node: "rubrik.demo.com"
         rubrik_user: "foo"
         rubrik_pass: "bar"


### PR DESCRIPTION
Facing the following error when running the cluster_info playbook:

```
~/work/ansible-rubrik$ ansible-playbook cluster_info.yml 
 [WARNING]: provided hosts list is empty, only localhost is available

ERROR! no action detected in task

The error appears to have been in '/home/tta/work/ansible-rubrik/cluster_info.yml': line 4, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - test_conn:
      ^ here
1 Comment Collapse
```


After the change: 

```
TASK [cluster_info] ************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: Value of unknown type: <class 'rubrik_lib.models.cluster_info.ClusterInfo'>, {'version': u'4.0.5-607', 'id': u'c0aa3315-f175-4530-b86a-535d00ade2f1', 'api_version': u'1'}
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "parsed": false}
```