### PR TITLE
Add Check mode support to rubrik_login_banner

### DIFF
--- a/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
@@ -91,14 +91,18 @@ def main():
         rubrik = rubrik_cdm.Connect(node_ip, username, password, api_token)
     except Exception as error:
         module.fail_json(msg=str(error))
+    #setup a check-mode message that resembles the idempotence checks of the python-sdk cdm
     if module.check_mode:
         bannerresponse = rubrik.get("internal", "/cluster/me/login_banner", timeout=ansible["timeout"])
         if bannerresponse["loginBanner"] == ansible["banner_text"]:
             results["changed"] = False
-            results["response"] = "Check-Mode: No change required. The Rubrik cluster is already configured with the login banner text '`banner`'."
+            results["response"] = "check-mode: No change required. The Rubrik cluster is already configured with the login banner text '`banner`'."
             module.exit_json(**results)
         results["changed"]=True
-        results["response"]=bannerresponse
+        if "loginBanner" in bannerresponse:
+            results["response"] = "check-mode: would have changed: \""+bannerresponse["loginBanner"]+ "\" => \""+ ansible["banner_text"]+"\""
+        else:
+            results["response"] = "check-mode: would have changed: UNSET => \""+ ansible["banner_text"]+"\""
         module.exit_json(**results) 
     try:
         api_request = rubrik.configure_login_banner(ansible["banner_text"], ansible["timeout"])

--- a/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
@@ -76,7 +76,7 @@ def main():
 
     argument_spec.update(rubrik_argument_spec)
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     ansible = module.params
 
@@ -91,7 +91,15 @@ def main():
         rubrik = rubrik_cdm.Connect(node_ip, username, password, api_token)
     except Exception as error:
         module.fail_json(msg=str(error))
-
+    if self.module.check_mode:
+        bannerresponse = rubrik.get("internal", "/cluster/me/login_banner", timeout=ansible["timeout"])
+        if bannerresponse["loginBanner"] == ansible["banner_text"]:
+            results["changed"] = False
+            results["response"] = "Check-Mode: No change required. The Rubrik cluster is already configured with the login banner text '`banner`'."
+            return
+        results["changed"]=True
+        results["response"]=bannerresponse
+        return 
     try:
         api_request = rubrik.configure_login_banner(ansible["banner_text"], ansible["timeout"])
     except Exception as error:

--- a/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
@@ -91,15 +91,15 @@ def main():
         rubrik = rubrik_cdm.Connect(node_ip, username, password, api_token)
     except Exception as error:
         module.fail_json(msg=str(error))
-    if self.module.check_mode:
+    if module.check_mode:
         bannerresponse = rubrik.get("internal", "/cluster/me/login_banner", timeout=ansible["timeout"])
         if bannerresponse["loginBanner"] == ansible["banner_text"]:
             results["changed"] = False
             results["response"] = "Check-Mode: No change required. The Rubrik cluster is already configured with the login banner text '`banner`'."
-            return
+            module.exit_json(**results)
         results["changed"]=True
         results["response"]=bannerresponse
-        return 
+        module.exit_json(**results) 
     try:
         api_request = rubrik.configure_login_banner(ansible["banner_text"], ansible["timeout"])
     except Exception as error:

--- a/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
@@ -104,7 +104,7 @@ def main():
             results["response"] = "check-mode: would have changed: \"" + bannerresponse["loginBanner"] + "\" => \"" + ansible["banner_text"] + "\""
         else:
             results["response"] = "check-mode: would have changed: UNSET => \"" + ansible["banner_text"] + "\""
-        module.exit_json(**results) 
+        module.exit_json(**results)
     try:
         api_request = rubrik.configure_login_banner(ansible["banner_text"], ansible["timeout"])
     except Exception as error:

--- a/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
+++ b/rubrikinc/cdm/plugins/modules/rubrik_login_banner.py
@@ -91,18 +91,19 @@ def main():
         rubrik = rubrik_cdm.Connect(node_ip, username, password, api_token)
     except Exception as error:
         module.fail_json(msg=str(error))
-    #setup a check-mode message that resembles the idempotence checks of the python-sdk cdm
+    # setup a check-mode message that resembles the idempotence checks of the python-sdk cdm
     if module.check_mode:
         bannerresponse = rubrik.get("internal", "/cluster/me/login_banner", timeout=ansible["timeout"])
         if bannerresponse["loginBanner"] == ansible["banner_text"]:
             results["changed"] = False
             results["response"] = "check-mode: No change required. The Rubrik cluster is already configured with the login banner text '`banner`'."
             module.exit_json(**results)
-        results["changed"]=True
+        results["changed"] = True
+
         if "loginBanner" in bannerresponse:
-            results["response"] = "check-mode: would have changed: \""+bannerresponse["loginBanner"]+ "\" => \""+ ansible["banner_text"]+"\""
+            results["response"] = "check-mode: would have changed: \"" + bannerresponse["loginBanner"] + "\" => \"" + ansible["banner_text"] + "\""
         else:
-            results["response"] = "check-mode: would have changed: UNSET => \""+ ansible["banner_text"]+"\""
+            results["response"] = "check-mode: would have changed: UNSET => \"" + ansible["banner_text"] + "\""
         module.exit_json(**results) 
     try:
         api_request = rubrik.configure_login_banner(ansible["banner_text"], ansible["timeout"])


### PR DESCRIPTION
# Description

Please describe your pull request in detail.

Add check-mode support to login_banner module

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_
#78 
## Motivation and Context

Why is this change required? What problem does it solve?

Adding this allows for "check-mode" switch to be used and returns whether the module would have made a change if the flag were removed.

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

Rubrik CDM 5.0.2
Ansible 2.9.8
RHEL 7.8

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/29983598/90167214-0396c480-dd61-11ea-8684-e43e70f827b2.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
